### PR TITLE
add tencent to queries in plugin.xml

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -107,6 +107,9 @@
             <uses-permission android:name="android.permission.ACCESS_WIFI_STATE"/>
             <uses-permission android:name="android.permission.READ_PHONE_STATE" />
             <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+            <queries>
+                <package android:name="com.tencent.mm" />
+            </queries>
         </config-file>
 
         <config-file target="AndroidManifest.xml" parent="/manifest/application">


### PR DESCRIPTION
We needed to fix Quantic's cordova android config in [this PR](https://github.com/quanticedu/back_royal/pull/10684) based on the solution found on [this site](https://open.weixin.qq.com/cgi-bin/announce?action=getannouncement&key=11600155960jI9EY&version=&lang=zh_CN&token=). I'm guessing this needs to be updated in the plugin.xml, based on Brent's comment to me in my PR. Thanks!